### PR TITLE
Add InnoMaker DAC to DAC configuration docs

### DIFF
--- a/DAC_configuration.md
+++ b/DAC_configuration.md
@@ -18,6 +18,7 @@ Please add the configuration values that work for your DAC to the table below.
 | [Pimoroni pHAT DAC][2] | hifiberry-dac                         |
 | [Justboom DAC HAT][3]  | justboom-dac                          |
 | [Pisound][4]           | pisound                               |
+| [InnoMaker][5]         | allo-boss-dac-pcm512x-audio           |
 
 
 
@@ -25,3 +26,4 @@ Please add the configuration values that work for your DAC to the table below.
 [2]: https://shop.pimoroni.com/products/phat-dac
 [3]: https://uk.pi-supply.com/products/justboom-dac-hat
 [4]: https://blokas.io/pisound/
+[5]: http://www.inno-maker.com/product/hifi-dac-hat/


### PR DESCRIPTION
I've tested an InnoMaker DAC purchased [here](https://www.amazon.com/Inno-Maker-Raspberry-PCM5122-Audio-Expansion/dp/B07D13QWV9/ref=sr_1_4?keywords=rpi+dac&qid=1580918982&sr=8-4) with this configuration and it does work.

Change-Type: patch
