### PR TITLE
Added PiFi Digi+ to DAC_configuration.md

### DIFF
--- a/DAC_configuration.md
+++ b/DAC_configuration.md
@@ -22,6 +22,7 @@ Please add the configuration values that work for your DAC to the table below.
 | [Hifiberry DAC+][6]    | hifiberry-dacplus                     | [Yes][7]
 | [InnoMaker][8]         | allo-boss-dac-pcm512x-audio           | [Yes][9]
 | [miniBoss DAC][10]      | allo-boss-dac-pcm512x-audio           | Yes
+| [PiFi Digi+][11]       | hifiberry-digi                        | Yes
 
 
 [1]: http://www.suptronics.com/Xseries/x400.html
@@ -34,3 +35,4 @@ Please add the configuration values that work for your DAC to the table below.
 [8]: http://www.inno-maker.com/product/hifi-dac-hat/
 [9]: https://github.com/balenalabs/balena-sound/pull/98
 [10]: https://allo.com/sparky/miniboss-rpi-zero.html
+[11]: http://www.kumantech.com/kuman-sc07-raspberry-pi-hifi-digi-digital-sound-card-i2s-spdif-optical-fiber-for-raspberry-pi-3-2-model-b-b-sc07_p0041.html


### PR DESCRIPTION
Change-Type: patch

Works fine using the optical cable with the Hifiberry Digi clone PiFi Digi+ using the hifiberry-digi overlay.

This makes it possible to build projects with digital outputs for receivers that do not yet have HDMI.