### PR TITLE
Readme should show where setup commands are run

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 # Setup and use
 
-Running this project is as simple as deploying it to a balenaCloud application; no additional configuration is required (unless you're using a DAC HAT).
+Running this project is as simple as deploying it to a balenaCloud application; no additional configuration is required (unless you're using a DAC HAT). All the setup steps below are done from your MacOS, Windows or Linux computer, not the Raspberry Pi.
 
 ### Setup the Raspberry Pi
 


### PR DESCRIPTION
Users are often confused when steps happen on the device and which steps should be run from their personal computer. This edit should make that distinction more clear.

Change-type: patch
Signed-off-by: Stef Kors <stef@balena.io>
