### PR TITLE
multi-room: add latency optional parameter to snapclient

### DIFF
--- a/snapcast-client/start.sh
+++ b/snapcast-client/start.sh
@@ -6,10 +6,15 @@ if [[ -z $DISABLE_MULTI_ROOM ]]; then
   # We need this because fleet-supervisor depends on resin_supervisor, which has no support for depends_on
   while ! curl -s "http://localhost:3000"; do sleep 1; done
 
+  # Add latency if defined to compensate for speaker hardware sync issues
+  if [[ -z $DEVICE_LATENCY ]]; then
+    LATENCY="--latency $DEVICE_LATENCY"
+  fi
+
   # Start snapclient
   SNAPCAST_SERVER=$(curl --silent http://localhost:3000)
   echo -e "Starting snapclient...\nTarget snapcast server: $SNAPCAST_SERVER"
-  snapclient -h $SNAPCAST_SERVER
+  snapclient -h $SNAPCAST_SERVER $LATENCY
 else
   echo "Multi-room audio is disabled, not starting snapclient."
   exit 0


### PR DESCRIPTION
Used to compensate for different hardware processing times in speakers.
Handled via $DEVICE_LATENCY

Change-type: minor
Signed-off-by: Tomás Migone <tomas@balena.io>
