### PR TITLE
Adding clarification between config vars and env vars for users

### DIFF
--- a/docs/03-customization.md
+++ b/docs/03-customization.md
@@ -1,13 +1,17 @@
 # Customizations
 
-You can configure some features of balenaSound by using environment variables. This can be set in the balena dashboard: 
+You can configure some features of balenaSound by using environment variables. This can be set in the balena dashboard within your app: 
 ```
 navigate to dashboard -> your app -> Environment variables. 
 ```
 
 ![Setting the device name](https://raw.githubusercontent.com/balenalabs/balena-sound/master/images/device-name-config.png)
 
+### Learn more about changing environment variables
+
 You can read more about environment variables [here](https://www.balena.io/docs/learn/manage/serv-vars/#fleet-environment-and-service-variables).
+
+**NOTE:** The [environment and device service variables](https://www.balena.io/docs/learn/manage/serv-vars/) are different than [configuration variables](https://www.balena.io/docs/learn/manage/configuration/) that make changes to the host OS and supervisor. For various balenaSound customizations, please apply or change [*environment or specific device variables*](https://www.balena.io/docs/learn/manage/serv-vars/).
 
 ## Change device name
 


### PR DESCRIPTION
Clarifying and citing resources for env var usage in balenaSound so users don't try to add env vars to config vars.

Change-type: patch
Signed-off-by: Andrew Nhem <andrewn@balena.io>