### PR TITLE
airplay, spotify, bluetooth: Device Variable/Name

### DIFF
--- a/airplay/start.sh
+++ b/airplay/start.sh
@@ -10,10 +10,13 @@ if [[ -z $DISABLE_MULTI_ROOM ]] && [[ $CLIENT_ONLY_MULTI_ROOM == "1" ]]; then
   exit 0
 fi
 
-
 # Set the device broadcast name for AirPlay
 if [[ -z "$DEVICE_NAME" ]]; then
-  DEVICE_NAME=$(printf "balenaSound Airplay %s" $(hostname | cut -c -4))
+   if [[ "$AIRPLAY_DEVICE_NAME" ]]; then
+     DEVICE_NAME="$AIRPLAY_DEVICE_NAME"
+   else
+     DEVICE_NAME=$(printf "balenaSound Airplay %s" $(hostname | cut -c -4))
+   fi
 fi
 
 # Use pipe output if multi room is enabled

--- a/bluetooth-audio/start.sh
+++ b/bluetooth-audio/start.sh
@@ -10,11 +10,12 @@ if [[ -z $DISABLE_MULTI_ROOM ]] && [[ $CLIENT_ONLY_MULTI_ROOM == "1" ]]; then
   exit 0
 fi
 
+# Set the device broadcast name for Bluetooth
 if [[ -z "$DEVICE_NAME" ]]; then
    if [[ "$BLUETOOTH_DEVICE_NAME" ]]; then
      DEVICE_NAME="$BLUETOOTH_DEVICE_NAME"
    else
-     DEVICE_NAME=$(printf "balenaSound %s" $(hostname | cut -c -4))
+     DEVICE_NAME=$(printf "balenaSound Bluetooth %s" $(hostname | cut -c -4))
    fi
 fi
 

--- a/spotify/start.sh
+++ b/spotify/start.sh
@@ -12,7 +12,11 @@ fi
 
 # Set the device broadcast name for Spotify
 if [[ -z "$DEVICE_NAME" ]]; then
-  DEVICE_NAME=$(printf "balenaSound Spotify %s" $(hostname | cut -c -4))
+   if [[ "$SPOTIFY_DEVICE_NAME" ]]; then
+     DEVICE_NAME="$SPOTIFY_DEVICE_NAME"
+   else
+     DEVICE_NAME=$(printf "balenaSound Spotify %s" $(hostname | cut -c -4))
+   fi
 fi
 
 # Set the system volume here


### PR DESCRIPTION
Modify start.sh scripts for spotify, airplay, and bluetooth so that all of them can have custom names through device variables. 

Change-type: minor