### PR TITLE
spotify: Environment variable to switch volume normalisation

### DIFF
--- a/spotify/start.sh
+++ b/spotify/start.sh
@@ -32,4 +32,8 @@ if [[ -z $DISABLE_MULTI_ROOM ]] && ! [[ $BALENA_DEVICE_TYPE == "raspberry-pi" ||
 fi
 
 # Start raspotify
-exec /usr/bin/librespot --name "$DEVICE_NAME" $SPOTIFY_BACKEND --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME $SPOTIFY_CREDENTIALS $SPOTIFY_DEVICE
+if [[ $DISABLE_VOLUME_NORMALISATION == "1" ]]; then
+  exec /usr/bin/librespot --name "$DEVICE_NAME" $SPOTIFY_BACKEND --bitrate 320 --cache /var/cache/raspotify --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME $SPOTIFY_CREDENTIALS $SPOTIFY_DEVICE
+else
+  exec /usr/bin/librespot --name "$DEVICE_NAME" $SPOTIFY_BACKEND --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME $SPOTIFY_CREDENTIALS $SPOTIFY_DEVICE
+fi


### PR DESCRIPTION
spotify: Add volume normalisation switch

this pr adds a new environment variable which will enable and disable volume normalisation

Change-type: patch
Connects-to:  #267 