### PR TITLE
balenaSound 3.x - initial version

### DIFF
--- a/core/audio/start.sh
+++ b/core/audio/start.sh
@@ -86,4 +86,9 @@ if [[ -n "$SOUND_ENABLE_SOUNDCARD_INPUT" ]]; then
   route_input_source
 fi
 
-exec pulseaudio --file /etc/pulse/balena-sound.pa
+exec pulseaudio \
+  --realtime=true \
+  --system=true \
+  --log-target=stderr \
+  --daemonize=false \
+  --file=/etc/pulse/balena-sound.pa


### PR DESCRIPTION
Launch pulseaudio with better options
    
- Use --system=true since we are anyway running it as root.
- Use `--log-target=stderr` and `--daemonize=false` so errors and warnings will
  show up better in the logs.
- Use `--realtime=true` to get better performance; Most notably, latency errors are gone thanks to this.

P.S I hope this won't get automatically merged by your bot.