### PR TITLE
meta: Use balenablocks images instead of balenaplayground

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,7 +97,7 @@ If your application does not have built-in PulseAudio support, you can create a 
 
 ```
 ENV PULSE_SERVER=tcp:localhost:4317
-RUN curl -sL https://raw.githubusercontent.com/balena-io-playground/audio-primitive/master/scripts/alsa-bridge/debian-setup.sh | sh
+RUN curl -sL https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh | sh
 ```
 
 Note that you still need to set the `PULSE_SERVER` variable.

--- a/core/audio/Dockerfile.template
+++ b/core/audio/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenaplayground/balenalabs-audio:%%BALENA_MACHINE_NAME%%
+FROM balenablocks/audio:%%BALENA_MACHINE_NAME%%
 
 WORKDIR /usr/src
 COPY . .

--- a/core/multiroom/client/Dockerfile.template
+++ b/core/multiroom/client/Dockerfile.template
@@ -3,7 +3,7 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:3.12
 RUN install_packages snapcast-client
 
 # Audio block setup
-RUN curl --silent https://raw.githubusercontent.com/balena-io-playground/audio-primitive/master/scripts/alsa-bridge/alpine-setup.sh | sh
+RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/alpine-setup.sh | sh
 ENV PULSE_SERVER=tcp:audio:4317
 ENV PULSE_SINK=balena-sound.output
 

--- a/docs/02-usage.md
+++ b/docs/02-usage.md
@@ -62,7 +62,7 @@ balenaSound has been re-designed to easily allow integration with audio streamin
 | Spotify | [raspotify](https://github.com/dtcooper/raspotify/)<br>Spotify Connect only works with Spotify Premium accounts.<br>If you have a Spotify Premium account, you can stream locally without any configuration.<br>If you want to use Spotify Connect over the internet, you'll need to provide your Spotify credentials. See [customization](../docs/customization#plugins) section for details. |
 | AirPlay | [shairport-sync](https://github.com/mikebrady/shairport-sync/) |
 | UPnP | [gmrenderer-resurrect](https://github.com/hzeller/gmrender-resurrect) |
-| Bluetooth | balena [bluetooth](https://github.com/balena-io-playground/bluetooth-primitive/) and [audio](https://github.com/balenablocks/audio) blocks |
+| Bluetooth | balena [bluetooth](https://github.com/balenablocks/bluetooth/) and [audio](https://github.com/balenablocks/audio) blocks |
 | Soundcard input | Experimental support through the balena [audio](https://github.com/balenablocks/audio) block. Check the [customization](../docs/customization#plugins) section to learn how to enable it. |
 
 If your desired audio source is not supported feel free to [reach out](../docs/support#contact-us) and leave us a comment. We've also considerably simplified the process of adding new plugins, so [PR's are welcome](../../contributing) too (be be sure to check out our balenaSound [architecture](../../contributing/architecture) guide)!

--- a/plugins/bluetooth/Dockerfile.template
+++ b/plugins/bluetooth/Dockerfile.template
@@ -1,3 +1,3 @@
-FROM balenaplayground/balenalabs-bluetooth:%%BALENA_MACHINE_NAME%%
+FROM balenablocks/bluetooth:%%BALENA_MACHINE_NAME%%
 
 # TODO: update bluetooth block to allow disabling

--- a/plugins/spotify/Dockerfile.aarch64
+++ b/plugins/spotify/Dockerfile.aarch64
@@ -6,7 +6,7 @@ RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - 2>
 
 # Audio block setup
 ENV PULSE_SERVER=tcp:localhost:4317
-RUN curl -sL https://raw.githubusercontent.com/balena-io-playground/audio-primitive/master/scripts/alsa-bridge/debian-setup.sh | sh
+RUN curl -sL https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh | sh
 
 COPY start.sh /usr/src/
 

--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -6,7 +6,7 @@ RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - 2>
 
 # Audio block setup
 ENV PULSE_SERVER=tcp:localhost:4317
-RUN curl -sL https://raw.githubusercontent.com/balena-io-playground/audio-primitive/master/scripts/alsa-bridge/debian-setup.sh | sh
+RUN curl -sL https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh | sh
 
 COPY start.sh /usr/src/
 


### PR DESCRIPTION
Use production images at `balenablocks` dockerhub org.

Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>
