### PR TITLE
Open port 1705 for snapcast clients to control snapcast server.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     restart: on-failure
     ports:
       - 1704:1704
+      - 1705:1705
     volumes:
       - snapcast:/var/cache/snapcast
 


### PR DESCRIPTION
Minor update to re-open the snapcast server control port.  Doing so allows interoperability with other systems which use similar technology stacks.  For example, one can control balenaSound client volume levels via the Snap.Net Windows snapcast client or the Android Snapcast app.
