### PR TITLE
multi-room: add snapweb to snapcast server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ landr-dist
 *.traineddata
 node_modules
 build
+core/multiroom/server/snapweb

--- a/core/multiroom/server/Dockerfile.template
+++ b/core/multiroom/server/Dockerfile.template
@@ -2,8 +2,11 @@ FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:3.12
 
 WORKDIR /usr/src
 
-RUN install_packages snapcast-server
+RUN install_packages snapcast-server git make npm
 COPY snapserver.conf /etc/snapserver.conf
 COPY start.sh .
+RUN git clone https://github.com/badaix/snapweb.git snapweb
+RUN npm install --global --no-save typescript
+RUN cd snapweb && make && mkdir -p /var/www && mv dist/* /var/www
 
 CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/core/multiroom/server/snapserver.conf
+++ b/core/multiroom/server/snapserver.conf
@@ -1,3 +1,13 @@
+[server]
+datadir = /var/cache/snapcast/ 
+
+[http]
+enabled = true
+bind_to_address = 0.0.0.0
+port = 1780
+doc_root = /var/www/
+
 [stream]
 stream = pipe:///var/cache/snapcast/snapfifo?name=balenaSound
 sampleformat = 44100:16:2
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     ports:
       - 1704:1704
       - 1705:1705
+      - 1780:1780
     volumes:
       - snapcast:/var/cache/snapcast
 


### PR DESCRIPTION
This adds the simple web application snapweb to the snapcast server.
The application allows to set properties of snapcast (multiroom) client
such as volume

Change-type: minor
Signed-off-by: emmanuel.jannetti@gmail.com
Connects-to: #319
