### PR TITLE
spotify: Add option to disable Spotify's audio cache

### DIFF
--- a/docs/03-customization.md
+++ b/docs/03-customization.md
@@ -15,7 +15,7 @@ You can read more about environment variables [here](https://www.balena.io/docs/
 
 ## General
 
-The following environment variables apply to balenaSound in general, modifying it's behavior across the board:
+The following environment variables apply to balenaSound in general, modifying its behavior across the board:
 
 | Environment variable | Description | Options | Default |
 | ------ | ------ | ------ | ------ |
@@ -42,9 +42,10 @@ The following environment variables control various aspects of each plugin behav
 
 | Environment variable | Description | Options | Defaults |
 | --- | --- | --- | --- |
-| SOUND_DISABLE_PLUGIN | Disable the selected plugin. Useful when you don't want to use a particular plugin. There is one variable per plugin: <br>- `SOUND_DISABLE_SPOTIFY`<br>- `SOUND_DISABLE_AIRPLAY`<br>- `SOUND_DISABLE_BLUETOOTH`<br>- `SOUND_DISABLE_UPNP` | Plugin will be disabled if the variable exists regardless of it's value. | --- |
-| SOUND_ENABLE_SOUNDCARD_INPUT | If your soundcard has inputs you can enable soundcard input by setting this variable. Sound coming in through the audio card will be treated as a new plugin/audio source.<br><br>This feature is still experimental! | Plugin will be enabled if the variable exists regardless of it's value. | --- |
+| SOUND_DISABLE_PLUGIN | Disable the selected plugin. Useful when you don't want to use a particular plugin. There is one variable per plugin: <br>- `SOUND_DISABLE_SPOTIFY`<br>- `SOUND_DISABLE_AIRPLAY`<br>- `SOUND_DISABLE_BLUETOOTH`<br>- `SOUND_DISABLE_UPNP` | Plugin will be disabled if the variable exists regardless of its value. | --- |
+| SOUND_ENABLE_SOUNDCARD_INPUT | If your soundcard has inputs you can enable soundcard input by setting this variable. Sound coming in through the audio card will be treated as a new plugin/audio source.<br><br>This feature is still experimental! | Plugin will be enabled if the variable exists regardless of its value. | --- |
 | SOUND_SPOTIFY_USERNAME | Your Spotify login username. Required to use Spotify Connect over the internet. | --- | --- |
 | SOUND_SPOTIFY_PASSWORD | Your Spotify login password. Required to use Spotify Connect over the internet. | --- | --- |
-| SOUND_SPOTIFY_DISABLE_NORMALISATION | Disable volume normalization in Spotify. | Disabled if the variable exists regardless of it's value. | --- |
+| SOUND_SPOTIFY_DISABLE_NORMALISATION | Disable volume normalization in Spotify. | Disabled if the variable exists regardless of its value. | --- |
+| SOUND_SPOTIFY_ENABLE_CACHE | Enable the audio cache in Spotify. Note that over time the cache can take up large amounts of disk space. | Enabled if the variable exists regardless of its value. | --- |
 | SOUND_SPOTIFY_BITRATE | Spotify playback bitrate. | Bitrate in kbps: `90`, `160` or `320` | 160 |

--- a/plugins/spotify/start.sh
+++ b/plugins/spotify/start.sh
@@ -25,12 +25,19 @@ if [[ -n "$SOUND_SPOTIFY_USERNAME" ]] && [[ -n "$SOUND_SPOTIFY_PASSWORD" ]]; the
     --password "$SOUND_SPOTIFY_PASSWORD"
 fi
 
+# SOUND_SPOTIFY_DISABLE_CACHE: Disable Spotify audio cache
+if [[ -z "$SOUND_SPOTIFY_ENABLE_CACHE" ]]; then
+  set -- "$@" \
+    --disable-audio-cache
+fi
+
 # Start librespot
 # We use set/$@ because librespot for some reason does not like env vars and quote escapes
 echo "Starting Spotify plugin..."
 echo "Device name: $SOUND_DEVICE_NAME"
 [[ -n "$SOUND_SPOTIFY_USERNAME" ]] && [[ -n "$SOUND_SPOTIFY_PASSWORD" ]] && echo "Using provided credentials for Spotify login."
 [[ -z "$SOUND_SPOTIFY_DISABLE_NORMALISATION" ]] && echo "Volume normalization enabled."
+[[ -z "$SOUND_SPOTIFY_ENABLE_CACHE" ]] && echo "Spotify audio cache disabled."
 
 set -- /usr/bin/librespot \
   --name "$SOUND_DEVICE_NAME" \


### PR DESCRIPTION
This feature allows the user to enable Spotify's audio cache by setting the SOUND_SPOTIFY_ENABLE_CACHE environment variable. The cache is now disabled by default to avoid full filesystem issues.

Connects-to: #367
Change-type: patch
Signed-off-by: Roddie Hasan <roddie@krweb.net>