### PR TITLE
spotify: fix linear volume control issue

### DIFF
--- a/plugins/spotify/start.sh
+++ b/plugins/spotify/start.sh
@@ -36,7 +36,7 @@ set -- /usr/bin/librespot \
   --name "$SOUND_DEVICE_NAME" \
   --bitrate "$SOUND_SPOTIFY_BITRATE" \
   --cache /var/cache/raspotify \
-  --linear-volume \
+  --volume-ctrl linear \
   "$@"
 
 exec "$@"


### PR DESCRIPTION
rasptify updated their librepsot debs to pull in the new changes in librespot to move away from --linear-volume and to either --mixer-linear-volume or --volume-ctrl linear. The latter seems to be the preferred option judging by their latest docs update.

Change-type: patch
Connects-to: #386
Closes: #386
Signed-off-by: Aaron Shaw <aaron@balena.io>
Co-authored-by: eiddor <roddie@krweb.net>
Co-authored-by: wusala01 <nick.london94@gmail.com>