### PR TITLE
multiroom: fix snapcast version

### DIFF
--- a/core/audio/start.sh
+++ b/core/audio/start.sh
@@ -85,7 +85,7 @@ SOUND_INPUT_LATENCY=${SOUND_INPUT_LATENCY:-200}
 SOUND_OUPUT_LATENCY=${SOUND_OUTPUT_LATENCY:-200}
 
 # Audio routing: route intermediate balena-sound input/output sinks
-echo "Setting audio routing rules. Note that this can be changed after startup."
+echo "Setting audio routing rules..."
 reset_sound_config
 route_input_sink "$MODE"
 route_output_sink

--- a/core/multiroom/client/Dockerfile.template
+++ b/core/multiroom/client/Dockerfile.template
@@ -1,14 +1,14 @@
-# Minimum snapcast version for ALSA stream source is v0.21
-# Currently Alpine 3.12 is pinned to snapcast v0.19 so we need to use Alpine edge
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:edge
+# TODO: don't rely on bullseye repository pinning because it could change with no warning
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:bullseye
+
 WORKDIR /usr/src
 
-RUN install_packages snapcast-client
+RUN install_packages snapclient
 
 # Audio block setup
 ENV PULSE_SERVER=tcp:audio:4317
 ENV PULSE_SINK=balena-sound.output
-RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/alpine-setup.sh | sh
+RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh | sh
 
 COPY start.sh .
 

--- a/core/multiroom/client/start.sh
+++ b/core/multiroom/client/start.sh
@@ -16,6 +16,7 @@ SNAPSERVER=$(curl --silent "$SOUND_SUPERVISOR/multiroom/master" || true)
 LATENCY=${SOUND_MULTIROOM_LATENCY:+"--latency $SOUND_MULTIROOM_LATENCY"}
 
 echo "Starting multi-room client..."
+echo "$(snapclient --version | head -n 1)"
 echo "Mode: $MODE"
 echo "Target snapcast server: $SNAPSERVER"
 
@@ -29,9 +30,6 @@ fi
 
 # Start snapclient
 if [[ "$MODE" == "MULTI_ROOM" || "$MODE" == "MULTI_ROOM_CLIENT" ]]; then
-  # Start snapclient and filter out those pesky chunk logs
-  # grep filter can be removed when we get snapcast v0.20
-  # see: https://github.com/badaix/snapcast/issues/559#issuecomment-615874719
   /usr/bin/snapclient --host $SNAPSERVER $LATENCY --hostID $SNAPCAST_CLIENT_ID --logfilter *:notice
 else
   echo "Multi-room client disabled. Exiting..."

--- a/core/multiroom/server/Dockerfile.template
+++ b/core/multiroom/server/Dockerfile.template
@@ -8,9 +8,9 @@ RUN git clone https://github.com/badaix/snapweb.git snapweb
 RUN npm install --global --no-save typescript
 RUN cd snapweb && make
 
-# Minimum snapcast version for ALSA stream source is v0.21
-# Currently Alpine 3.12 is pinned to snapcast v0.19 so we need to use Alpine edge
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:edge
+# TODO: don't rely on bullseye repository pinning because it could change with no warning
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:bullseye
+
 WORKDIR /usr/src
 
 # Install snapweb
@@ -18,13 +18,13 @@ RUN mkdir -p /var/www
 COPY --from=web-builder /usr/src/snapweb/dist/* /var/www/
 
 # Install snapcast
-RUN install_packages snapcast-server
+RUN install_packages snapserver
 COPY snapserver.conf /etc/snapserver.conf
 COPY start.sh .
 
 # Audio block setup
 ENV PULSE_SERVER=tcp:audio:4317
 ENV PULSE_SOURCE=snapcast.monitor
-RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/alpine-setup.sh| sh
+RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh| sh
 
 CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/core/multiroom/server/start.sh
+++ b/core/multiroom/server/start.sh
@@ -28,6 +28,7 @@ fi
 
 # Start snapserver
 echo "Starting multi-room server..."
+echo "$(snapserver --version | head -n 1)"
 echo "Mode: $MODE"
 
 if [[ "$MODE" == "MULTI_ROOM" ]]; then


### PR DESCRIPTION
Latest snapcast release on alpine edge is not working properly.
Going back to debian to get snapcast v0.23.
This increases container size considerably though :/

Connects-to: #423
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>
