### PR TITLE
Multiroom improvements

### DIFF
--- a/core/multiroom/client/Dockerfile.template
+++ b/core/multiroom/client/Dockerfile.template
@@ -1,14 +1,8 @@
-# TODO: don't rely on bullseye repository pinning because it could change with no warning
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:bullseye
-
+FROM balenablocks/multiroom:rpi
 WORKDIR /usr/src
 
-RUN install_packages snapclient
-
-# Audio block setup
 ENV PULSE_SERVER=tcp:audio:4317
 ENV PULSE_SINK=balena-sound.output
-RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh | sh
 
 COPY start.sh .
 

--- a/core/multiroom/client/start.sh
+++ b/core/multiroom/client/start.sh
@@ -17,9 +17,8 @@ SNAPSERVER=$(curl --silent "$SOUND_SUPERVISOR/multiroom/master" || true)
 LATENCY=${SOUND_MULTIROOM_LATENCY:+"--latency $SOUND_MULTIROOM_LATENCY"}
 
 echo "Starting multi-room client..."
-echo "$(snapclient --version | head -n 1)"
-echo "Mode: $MODE"
-echo "Target snapcast server: $SNAPSERVER"
+echo "- balenaSound mode: $MODE"
+echo "- Target snapcast server: $SNAPSERVER"
 
 # Set the snapcast device name for https://github.com/balenalabs/balena-sound/issues/332
 if [[ -z $SOUND_DEVICE_NAME ]]; then
@@ -31,7 +30,7 @@ fi
 
 # Start snapclient
 if [[ "$MODE" == "MULTI_ROOM" || "$MODE" == "MULTI_ROOM_CLIENT" ]]; then
-  /usr/bin/snapclient --host $SNAPSERVER $LATENCY --hostID $SNAPCAST_CLIENT_ID --logfilter *:notice
+  /usr/bin/snapclient --player pulse --host $SNAPSERVER $LATENCY --hostID $SNAPCAST_CLIENT_ID --logfilter *:error
 else
   echo "Multi-room client disabled. Exiting..."
   exit 0

--- a/core/multiroom/server/Dockerfile.template
+++ b/core/multiroom/server/Dockerfile.template
@@ -1,30 +1,10 @@
-# Build snapweb separately
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine-node:latest as web-builder
+FROM balenablocks/multiroom
 WORKDIR /usr/src
 
-RUN install_packages git make npm
-
-RUN git clone https://github.com/badaix/snapweb.git snapweb
-RUN npm install --global --no-save typescript
-RUN cd snapweb && make
-
-# TODO: don't rely on bullseye repository pinning because it could change with no warning
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:bullseye
-
-WORKDIR /usr/src
-
-# Install snapweb
-RUN mkdir -p /var/www
-COPY --from=web-builder /usr/src/snapweb/dist/* /var/www/
-
-# Install snapcast
-RUN install_packages snapserver
-COPY snapserver.conf /etc/snapserver.conf
-COPY start.sh .
-
-# Audio block setup
 ENV PULSE_SERVER=tcp:audio:4317
 ENV PULSE_SOURCE=snapcast.monitor
-RUN curl --silent https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh| sh
+
+COPY snapserver.conf /etc/snapserver.conf
+COPY start.sh .
 
 CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/core/multiroom/server/snapserver.conf
+++ b/core/multiroom/server/snapserver.conf
@@ -12,4 +12,4 @@ stream = alsa://?name=balenaSound&device=pulse
 sampleformat = 44100:16:2
 
 [logging]
-filter = *:notice
+filter = *:error

--- a/core/multiroom/server/start.sh
+++ b/core/multiroom/server/start.sh
@@ -27,11 +27,8 @@ if [[ -n "${blacklisted[$BALENA_DEVICE_TYPE]}" ]]; then
 fi
 
 # Start snapserver
-echo "Starting multi-room server..."
-echo "$(snapserver --version | head -n 1)"
-echo "Mode: $MODE"
-
 if [[ "$MODE" == "MULTI_ROOM" ]]; then
+  echo "Starting multi-room server..."
   /usr/bin/snapserver
 else
   echo "Multi-room server disabled. Exiting..."

--- a/core/sound-supervisor/src/SoundConfig.ts
+++ b/core/sound-supervisor/src/SoundConfig.ts
@@ -31,10 +31,8 @@ export default class SoundConfig {
   }
 
   setMultiRoomMaster(master: string) {
-    if (!this.multiroom.forced) {
-      this.multiroom.master = master
-      restartBalenaService('multiroom-client')
-    }
+    this.multiroom.master = master
+    restartBalenaService('multiroom-client')
   }
 
   // TODO: Fix bug - This won't work if there are USB or DAC sound cards because it currently relies on hardcoded sink|sinkInput indexes

--- a/core/sound-supervisor/src/constants.ts
+++ b/core/sound-supervisor/src/constants.ts
@@ -19,8 +19,10 @@ export const constants = {
   multiroom: {
     master: process.env.SOUND_MULTIROOM_MASTER,
     forced: process.env.SOUND_MULTIROOM_MASTER ? true : false,
-    pollInterval: (checkInt(process.env.SOUND_MULTIROOM_POLL_INTERVAL) ?? 60) * 1000
+    pollInterval: (checkInt(process.env.SOUND_MULTIROOM_POLL_INTERVAL) ?? 60) * 1000,
+    disallowUpdates: process.env.SOUND_MULTIROOM_DISALLOW_UPDATES ? true : false
   },
-  volume: checkInt(process.env.SOUND_VOLUME) ?? 75
+  volume: checkInt(process.env.SOUND_VOLUME) ?? 75,
+  inputSink: process.env.SOUND_INPUT_SINK ?? 'balena-sound.input'
 }
 

--- a/core/sound-supervisor/src/constants.ts
+++ b/core/sound-supervisor/src/constants.ts
@@ -18,7 +18,8 @@ export const constants = {
   balenaDeviceType: deviceType,
   multiroom: {
     master: process.env.SOUND_MULTIROOM_MASTER,
-    forced: process.env.SOUND_MULTIROOM_MASTER ? true : false
+    forced: process.env.SOUND_MULTIROOM_MASTER ? true : false,
+    pollInterval: (checkInt(process.env.SOUND_MULTIROOM_POLL_INTERVAL) ?? 60) * 1000
   },
   volume: checkInt(process.env.SOUND_VOLUME) ?? 75
 }

--- a/core/sound-supervisor/src/index.ts
+++ b/core/sound-supervisor/src/index.ts
@@ -3,7 +3,6 @@ import BalenaAudio from './audio-block'
 import SoundAPI from './SoundAPI'
 import SoundConfig from './SoundConfig'
 import { constants } from './constants'
-import { resolve } from 'path'
 
 // balenaSound core
 const config: SoundConfig = new SoundConfig()
@@ -44,14 +43,14 @@ async function init() {
 // Event: "play"
 // Source: audio block
 // On audio playback, set this server as the multiroom-master
-// We check balena-sound.input as it's the sink that receives all audio sources
+// We check the input sink that receives all audio sources
 audioBlock.on('play', (sink: any) => {
   if (constants.debug) {
     console.log(`[event] Audio block: play`)
     console.log(sink)
   }
 
-  if (config.isMultiRoomServer() && sink.name === 'balena-sound.input') {
+  if (config.isMultiRoomServer() && sink.name === constants.inputSink) {
     console.log(`Playback started, announcing ${config.device.ip} as multi-room master!`)
     fleetPublisher.publish('fleet-update', { type: 'master', master: config.device.ip })
   }
@@ -66,7 +65,7 @@ fleetSubscriber.on('fleet-update', async (data: any) => {
     console.log(data)
   }
 
-  if (config.isNewMultiRoomMaster(data.master)) {
+  if (config.isNewMultiRoomMaster(data.master) && !config.multiroom.forced && !constants.multiroom.disallowUpdates) {
     console.log(`Multi-room master has changed to ${data.master}, restarting snapcast-client...`)
     config.setMultiRoomMaster(data.master)
   }

--- a/core/sound-supervisor/src/index.ts
+++ b/core/sound-supervisor/src/index.ts
@@ -3,6 +3,7 @@ import BalenaAudio from './audio-block'
 import SoundAPI from './SoundAPI'
 import SoundConfig from './SoundConfig'
 import { constants } from './constants'
+import { resolve } from 'path'
 
 // balenaSound core
 const config: SoundConfig = new SoundConfig()
@@ -27,14 +28,21 @@ async function init() {
 
   // For multi room, allow cote to establish connections before sending fleet-sync
   if (config.isMultiRoomEnabled()) {
-    setTimeout(() => {
-      console.log('Joining the fleet, requesting master info with fleet-sync...')
-      fleetPublisher.publish('fleet-sync', { type: 'sync', origin: config.device.ip })
-    }, constants.coteDelay)
+    await timeout(constants.coteDelay)
+    console.log('Joining the fleet, requesting master info with fleet-sync...')
+    fleetPublisher.publish('fleet-sync', { type: 'sync', origin: config.device.ip })
   }
+
+  // Periodically sync the fleet
+  setInterval(() => {
+    if (config.isMultiRoomEnabled()) {
+      fleetPublisher.publish('fleet-sync', { type: 'sync', origin: config.device.ip })
+    }
+  }, constants.multiroom.pollInterval)
 }
 
 // Event: "play"
+// Source: audio block
 // On audio playback, set this server as the multiroom-master
 // We check balena-sound.input as it's the sink that receives all audio sources
 audioBlock.on('play', (sink: any) => {
@@ -42,6 +50,7 @@ audioBlock.on('play', (sink: any) => {
     console.log(`[event] Audio block: play`)
     console.log(sink)
   }
+
   if (config.isMultiRoomServer() && sink.name === 'balena-sound.input') {
     console.log(`Playback started, announcing ${config.device.ip} as multi-room master!`)
     fleetPublisher.publish('fleet-update', { type: 'master', master: config.device.ip })
@@ -49,12 +58,14 @@ audioBlock.on('play', (sink: any) => {
 })
 
 // Event: "fleet-update"
+// Source: fleet
 // If the master server changed, reset multiroom-client service
 fleetSubscriber.on('fleet-update', async (data: any) => {
   if (constants.debug) {
-    console.log(`[event] cote: fleet-update`)
+    console.log(`[event] fleet: fleet-update`)
     console.log(data)
-  }  
+  }
+
   if (config.isNewMultiRoomMaster(data.master)) {
     console.log(`Multi-room master has changed to ${data.master}, restarting snapcast-client...`)
     config.setMultiRoomMaster(data.master)
@@ -62,14 +73,20 @@ fleetSubscriber.on('fleet-update', async (data: any) => {
 })
 
 // Event: "fleet-sync"
-// Whenever a device joins the network, re-announce current master
+// Source: fleet
+// When it receives this event the multiroom master announces itself as the master
+// This happens when a new device joines the fleet but also periodically
 fleetSubscriber.on('fleet-sync', (data: any) => {
   if (constants.debug) {
-    console.log(`[event] cote: fleet-sync`)
+    console.log(`[event] fleet: fleet-sync`)
     console.log(data)
   }
+
   if (config.isMultiRoomMaster() && data.origin !== config.device.ip) {
-    console.log(`New multi-room device joined, syncing fleet...`)
     fleetPublisher.publish('fleet-update', { type: 'master', master: config.multiroom.master })
   }
 })
+
+async function timeout (delay: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, delay))
+}

--- a/docs/03-customization.md
+++ b/docs/03-customization.md
@@ -36,6 +36,7 @@ These options only have an effect on multi-room behavior:
 | ---                     | ---                                                                                                                                                        | ---                                                   | ---     |
 | SOUND_MULTIROOM_MASTER  | Force multi-room to use the specified IP address as the multi-room `master` device. This can't be changed unless the variable is removed.                  | An IPv4 formatted IP address. Example: `192.168.1.10` | ---     |
 | SOUND_MULTIROOM_LATENCY | Set multi-room client latency. Usually used to compensate for latency that speaker hardware might introduce (some Hi-Fi systems add a noticeable latency). | Time in milliseconds. Example: `300`                  | ---     |
+| SOUND_MULTIROOM_POLL_INTERVAL | Set how often multi-room devices sync up across the fleet. | Time in seconds. Example: `120`                                                    | `60` |
 
 ## Plugins
 

--- a/docs/03-customization.md
+++ b/docs/03-customization.md
@@ -37,6 +37,7 @@ These options only have an effect on multi-room behavior:
 | SOUND_MULTIROOM_MASTER  | Force multi-room to use the specified IP address as the multi-room `master` device. This can't be changed unless the variable is removed.                  | An IPv4 formatted IP address. Example: `192.168.1.10` | ---     |
 | SOUND_MULTIROOM_LATENCY | Set multi-room client latency. Usually used to compensate for latency that speaker hardware might introduce (some Hi-Fi systems add a noticeable latency). | Time in milliseconds. Example: `300`                  | ---     |
 | SOUND_MULTIROOM_POLL_INTERVAL | Set how often multi-room devices sync up across the fleet. | Time in seconds. Example: `120`                                                    | `60` |
+| SOUND_MULTIROOM_DISALLOW_UPDATES | Prevent a device to update it's multi-room `master` based on fleet activity. | Boolean. `true` / `false`                                                    | `false` |
 
 ## Plugins
 


### PR DESCRIPTION
Changelog:
- Use multiroom block. This reduces 10x the image size for both multiroom containers (~350MB down to ~35MB, expanded). Also gives us finer control over the snapcast version being used.
- Improve fleet sync with a periodic update being sent between devices. Previously only at boot and play.
- Allow disabling fleet sync updates.