### PR TITLE
airplay: fix connection bug with airplay

### DIFF
--- a/plugins/airplay/start.sh
+++ b/plugins/airplay/start.sh
@@ -17,7 +17,7 @@ echo "Device name: $SOUND_DEVICE_NAME"
 # See: https://github.com/mikebrady/shairport-sync/issues/1054
 # Remove when above issue is addressed
 SOUND_SUPERVISOR_PORT=${SOUND_SUPERVISOR_PORT:-80}
-SOUND_SUPERVISOR="$(ip route | awk '/default / { print $3 }'):$SOUND_SUPERVISOR_PORT"
+SOUND_SUPERVISOR="http://localhost:$SOUND_SUPERVISOR_PORT"
 while ! curl --silent --output /dev/null "$SOUND_SUPERVISOR/ping"; do sleep 5; echo "Waiting for audioblock to start..."; done
 
 # Start AirPlay


### PR DESCRIPTION
The way AirPlay service was getting the `sound-supervisor` internal IP address was incorrect. We were using `ip route | awk '/default / { print $3 }'` which in `network_mode: host` containers such as AirPlay returns the network router's IP address instead of the device IP address which is what we need to access `sound-supervisor`. 

The IP address is **only** used to halt AirPlay's initialisation until `sound-supervisor` indicates it's safe to start it (see [here](https://github.com/balenalabs/balena-sound/blob/dedeebbd53f5bcd8fc962415f5aed62bd4c23781/plugins/airplay/start.sh#L21)). This is done via a `curl` command, since we were hitting the router with the command depending on your router it would return different results which means problems due to this bug were not so easy to identify or replicate. 

This bugfix solves several known problems with AirPlay described below:

**1) AirPlay service not starting, stuck waiting for audioblock to start**
Error logged: 
- `airplay Waiting for audioblock to start...`

This was caused because the network router would not respond to the curl command so the AirPlay service would be stuck in the curl check. 

Some examples: #489, #497, #501

**2) AirPlay service starting but throwing errors**
Errors logged include:
- `fatal error: pa context is not good -- the error message "Connection refused".`
- `fatal error: pa context is not good -- the error message "Connection terminated".`
- `fatal error: could not connect to the pulseaudio playback stream -- the error message is "Bad state".`

This was caused by the router responding to the curl request with a 404 or any other HTTP code. The service would start immediately, most likely before `sound-supervisor` and `audio` services were properly started so the AirPlay service would crash and then due to https://github.com/mikebrady/shairport-sync/issues/1054 it would not exit and be restarted. In this case restarting the service fixed the issue.

Some examples: #483, #463, #379

**3) A couple other seemingly random AirPlay errors**
In balena forums we had several repors where users reported inconsistent AirPlay behaviour that was solved upon restarting the service. This is most likely also caused by AirPlay starting too early as described in the previous item.

---

Special thanks to user **`TJvV`** from https://forums.balena.io which made the investigation that led to this fix. See https://forums.balena.io/t/airplay-is-not-visible-waiting-for-audioblock-to-start/349397/12 for details.

Closes: #379, #463, #483, #489, #497, #501
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>