### PR TITLE
meta: replace balena/build CI with balena-ci GitHub action

### DIFF
--- a/.github/workflows/balena-ci.yml
+++ b/.github/workflows/balena-ci.yml
@@ -1,0 +1,21 @@
+name: balenaCloud 
+
+on:
+ pull_request:
+    types: [opened, synchronize, closed]
+    branches:
+      - master
+
+jobs:
+  deploy-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: balena-io/balena-ci@master
+        name: Deploy to balenaCloud
+        with:
+          balena_token: ${{ secrets.BALENA_TOKEN }}
+          fleet: balenalabs/balenasound
+          versionbot: true
+      - name: Log release ID built
+        run: echo "Built release ID ${{ steps.build.outputs.release_id }}"


### PR DESCRIPTION
balena-ci GitHub action replaces old build check and automatically builds and pushes release for balenaSound open fleet

Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>
