### PR TITLE
ci: remove balena build check

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,1 +1,1 @@
-type: balena
+type: generic


### PR DESCRIPTION
Replaced by deploy-to-balena github action

Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>
