### PR TITLE
patch: Set hostname with balenablocks/hostname

### DIFF
--- a/core/audio/start.sh
+++ b/core/audio/start.sh
@@ -95,10 +95,4 @@ if [[ -n "$SOUND_ENABLE_SOUNDCARD_INPUT" ]]; then
   route_input_source
 fi
 
-# openFleets: configure hostname
-curl -sX PATCH --header "Content-Type:application/json" \
-    --data '{"network": {"hostname": "balena"}}' \
-    "$BALENA_SUPERVISOR_ADDRESS/v1/device/host-config?apikey=$BALENA_SUPERVISOR_API_KEY" \
-    --output /dev/null
-
 exec pulseaudio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     privileged: true
     labels:
       io.balena.features.dbus: 1
-      io.balena.features.supervisor-api: 1
     ports:
       - 4317:4317
 
@@ -65,3 +64,12 @@ services:
     network_mode: host
     volumes:
       - spotifycache:/var/cache/raspotify
+
+  # https://github.com/balenablocks/hostname
+  hostname:
+    image: balenablocks/hostname:latest
+    restart: no
+    labels:
+      io.balena.features.supervisor-api: 1
+    environment:
+      SET_HOSTNAME: balena


### PR DESCRIPTION
## Set hostname with balenablocks/hostname

I'm running [Pi-hole](https://github.com/klutchell/balena-pihole) and [balenaSound](https://github.com/balenalabs/balena-sound) mashup on RPi4 (https://www.balena.io/blog/two-projects-one-device-turn-your-raspberry-pi-into-a-multitool/).
 
The Pi-hole from [v2021.9.0](https://github.com/klutchell/balena-pihole/releases/tag/v2021.9.0) version is setting the custom hostname with [balenablocks/hostname](https://github.com/balenablocks/hostname) in its [docker-compose.yml](https://github.com/klutchell/balena-pihole/blob/v2021.9.0/docker-compose.yml#L36).

The latest balenaSound is still using the old way and curl the Supervisor API in its [core/audio](https://github.com/balenalabs/balena-sound/blob/master/core/audio/start.sh#L99) component.

Combining both approaches doesn't work well - the device network becomes erratic and services are randomly restarting. Even the SSH connection (using a standalone SSH client on a local network) becomes unstable and it is often interrupted with "`Bad packet length 109354353. ssh_dispatch_run_fatal: Connection to XX.XX.XX.XX port 22222: Connection corrupted`" errors.

I'm not sure what exactly is causing such problems if setting hostname to two different values or setting hostname from two different places or even some Supervisor limitations.

Note: I didn't test the change on the device running solely balenaSound, only in combination with Pi-hole.
