### PR TITLE
audio: fix no sound bug

### DIFF
--- a/core/audio/balena-sound.pa
+++ b/core/audio/balena-sound.pa
@@ -5,11 +5,11 @@ load-module module-null-sink sink_name=balena-sound.input
 load-module module-null-sink sink_name=balena-sound.output
 load-module module-null-sink sink_name=snapcast
 
+# Route all plugin input to the default sink
+set-default-sink balena-sound.input
+
 # Route audio internally, loopback sinks depend on configuration. See start.sh for details:
 # balena-sound.input: For multiroom it's routed to snapcast sink, for standalone directly wired to balena-sound.output
 # balena-sound.output: Set to audio sink specified by audio block
-load-module module-loopback latency_msec=%INPUT_LATENCY% source="balena-sound.input.monitor" %INPUT_SINK%
-load-module module-loopback latency_msec=%OUTPUT_LATENCY% source="balena-sound.output.monitor" %OUTPUT_SINK%
-
-# Route all plugin input to the default sink
-set-default-sink balena-sound.input
+load-module module-loopback latency_msec=%INPUT_LATENCY% source=balena-sound.input.monitor %INPUT_SINK%
+load-module module-loopback latency_msec=%OUTPUT_LATENCY% source=balena-sound.output.monitor %OUTPUT_SINK%

--- a/core/audio/start.sh
+++ b/core/audio/start.sh
@@ -26,12 +26,12 @@ function route_input_sink() {
 
   case "${options[$MODE]}" in
     ${options["STANDALONE"]} | ${options["MULTI_ROOM_CLIENT"]})
-      sed -i "s/%INPUT_SINK%/sink='balena-sound.output'/" "$CONFIG_FILE"
+      sed -i "s/%INPUT_SINK%/sink=balena-sound.output/" "$CONFIG_FILE"
       echo "Routing 'balena-sound.input' to 'balena-sound.output'."
       ;;
 
     ${options["MULTI_ROOM"]} | *)
-      sed -i "s/%INPUT_SINK%/sink=\"snapcast\"/" "$CONFIG_FILE"
+      sed -i "s/%INPUT_SINK%/sink=snapcast/" "$CONFIG_FILE"
       echo "Routing 'balena-sound.input' to 'snapcast'."
       ;;
   esac
@@ -44,7 +44,7 @@ function route_input_source() {
   if [[ -n "$INPUT_DEVICE" ]]; then
     local INPUT_DEVICE_FULLNAME="alsa_input.$INPUT_DEVICE.analog-stereo"
     echo "Routing audio from '$INPUT_DEVICE_FULLNAME' into 'balena-sound.input sink'"
-    echo -e "\nload-module module-loopback source='$INPUT_DEVICE_FULLNAME' sink='balena-sound.input'" >> "$CONFIG_FILE"
+    echo -e "\nload-module module-loopback source=$INPUT_DEVICE_FULLNAME sink=balena-sound.input" >> "$CONFIG_FILE"
   fi
 
 }
@@ -60,7 +60,7 @@ function route_output_sink() {
     OUTPUT=$(cat "$SINK_FILE")
   fi
   OUTPUT="${OUTPUT:-0}"
-  sed -i "s/%OUTPUT_SINK%/sink=\"$OUTPUT\"/" "$CONFIG_FILE"
+  sed -i "s/%OUTPUT_SINK%/sink=$OUTPUT/" "$CONFIG_FILE"
   echo "Routing 'balena-sound.output' to '$OUTPUT'."
 }
 


### PR DESCRIPTION
Fix a bug introduced by upgrading audio block to latest version running PulseAudio v15.

PulseAudio v14 introduced significant changes to stream behavior when changing default sink (described here: https://www.freedesktop.org/wiki/Software/PulseAudio/Notes/14.0/#significantroutingchangestodefaultsinkssources). 

Closes: #542, #543, #544, #545
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>