### PR TITLE
Implement support for the headless PlexAmp client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,3 +73,13 @@ services:
       io.balena.features.supervisor-api: 1
     environment:
       SET_HOSTNAME: balena
+      
+  plex: 
+    build: ./plugins/plex
+    restart: on-failure
+    privileged: true
+    network_mode: host
+    ports:
+      - 32500:32500
+    volumes:
+      - plex_settings:/root/.local/share/Plexamp

--- a/plugins/plex/Dockerfile.template
+++ b/plugins/plex/Dockerfile.template
@@ -1,0 +1,16 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-node:12.22.9
+
+
+RUN install_packages wget bzip2
+
+# Audio block setup
+ENV PULSE_SERVER=tcp:localhost:4317
+RUN curl -sL https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh | bash -s y
+
+WORKDIR /opt/plexamp
+ADD *.sh /opt/plexamp/
+
+RUN chmod +x start.sh
+RUN chmod +x plexamp-setup.sh && ./plexamp-setup.sh
+
+ENTRYPOINT /opt/plexamp/start.sh

--- a/plugins/plex/login.sh
+++ b/plugins/plex/login.sh
@@ -1,0 +1,11 @@
+if [[ -d "/root/.local/share/Plexamp/Settings" ]]; then
+    echo "Plexamp appears to be already configured, skipping..."
+    exit 1
+fi
+
+echo "When prompted, enter your claim token from https://plex.tv/claim"
+echo "Plexamp will start after entering, simply press control+c and restart the plex service to continue."
+
+cd /opt/plexamp/plexamp/
+
+node js/index.js

--- a/plugins/plex/plexamp-setup.sh
+++ b/plugins/plex/plexamp-setup.sh
@@ -1,0 +1,5 @@
+wget "https://plexamp.plex.tv/headless/Plexamp-Linux-arm64-v4.2.2-beta.7.tar.bz2" -O "plexamp.tar.bz2"
+
+tar -xf plexamp.tar.bz2 
+
+

--- a/plugins/plex/start.sh
+++ b/plugins/plex/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [[ -n "$SOUND_DISABLE_PLEX" ]]; then
+  echo "Plex is disabled, exiting..."
+  exit 0
+fi
+
+if [[ ! -d "/root/.local/share/Plexamp/Settings" ]]; then
+    echo "__________________________________________WARNING__________________________________________________"
+    echo "|                                  Plex is not configured!                                        |"
+    echo "| Please enter a shell into the Plex container and run `bash login.sh` to setup your credentials! |"
+    echo "|_________________________________________________________________________________________________|"
+    echo ""
+    echo "Note: This is likely to change as headless Plexamp versions are released with new features."
+    echo "  Passing a claim token via a command line argument has been suggested, we will have to see."
+    exit 1
+fi
+
+echo "Starting Plex plugin..."
+
+cd /opt/plexamp/plexamp/
+
+node js/index.js


### PR DESCRIPTION
Added a container build for the headless PlexAmp client, this will allow a user to use the plex app on a mobile device to cast music from their media server to their Balena Sound device.

Change-type: minor
Signed-off-by: Lewis L. Foster <lewis@sniff122.tech>

### Hey there, appreciated contributor!

Have you taken a look at the [contribution guidelines](https://sound.balenalabs.io/contributing/) for this project? To enable our CI to work correctly and version the releases of the project, you need to ensure your commit messages contain the required information [detailed here](https://sound.balenalabs.io/contributing/). Thank you!
